### PR TITLE
fix: return value of force_altitude consistent with bmp280

### DIFF
--- a/lib/bmp3xx.ex
+++ b/lib/bmp3xx.ex
@@ -79,7 +79,7 @@ defmodule BMP3XX do
   This function returns an error if the attempt to sample the current barometric
   pressure fails.
   """
-  @spec force_altitude(GenServer.server(), number) :: {:ok, number} | {:error, any}
+  @spec force_altitude(GenServer.server(), number) :: :ok | {:error, any}
   def force_altitude(server \\ __MODULE__, altitude_m) do
     GenServer.call(server, {:force_altitude, altitude_m})
   end
@@ -172,7 +172,7 @@ defmodule BMP3XX do
     sea_level_pa = BMP3XX.Calc.sea_level_pressure(state.last_measurement.pressure_pa, altitude_m)
     new_state = State.put_in_sensor(state, :sea_level_pa, sea_level_pa)
 
-    {:reply, {:ok, sea_level_pa}, new_state}
+    {:reply, :ok, new_state}
   end
 
   @impl GenServer

--- a/test/bmp3xx_test.exs
+++ b/test/bmp3xx_test.exs
@@ -23,7 +23,7 @@ defmodule BMP3XXTest do
 
   @tag sensor_type: :bmp380
   test "supports bmp380", %{bmp_name: bmp_name} do
-    {:ok, _} = BMP3XX.force_altitude(bmp_name, 100)
+    :ok = BMP3XX.force_altitude(bmp_name, 100)
     {:ok, measurement} = BMP3XX.measure(bmp_name)
     assert_in_delta measurement.temperature_c, 30.49, 0.1
     assert_in_delta measurement.pressure_pa, 100_876, 1
@@ -34,7 +34,7 @@ defmodule BMP3XXTest do
 
   @tag sensor_type: :bmp390
   test "supports bmp390", %{bmp_name: bmp_name} do
-    {:ok, _} = BMP3XX.force_altitude(bmp_name, 100)
+    :ok = BMP3XX.force_altitude(bmp_name, 100)
     {:ok, measurement} = BMP3XX.measure(bmp_name)
     assert_in_delta measurement.temperature_c, 30.49, 0.1
     assert_in_delta measurement.pressure_pa, 100_876, 1
@@ -45,7 +45,7 @@ defmodule BMP3XXTest do
 
   @tag sensor_type: :bmp180
   test "supports bmp180", %{bmp_name: bmp_name} do
-    {:ok, _} = BMP3XX.force_altitude(bmp_name, 100)
+    :ok = BMP3XX.force_altitude(bmp_name, 100)
     {:ok, measurement} = BMP3XX.measure(bmp_name)
     assert_in_delta measurement.temperature_c, 22.3, 0.1
     assert_in_delta measurement.pressure_pa, 101_132, 1
@@ -56,7 +56,7 @@ defmodule BMP3XXTest do
 
   @tag sensor_type: :bmp280
   test "supports bmp280", %{bmp_name: bmp_name} do
-    {:ok, _} = BMP3XX.force_altitude(bmp_name, 100)
+    :ok = BMP3XX.force_altitude(bmp_name, 100)
     {:ok, measurement} = BMP3XX.measure(bmp_name)
     assert_in_delta measurement.temperature_c, 26.7, 0.1
     assert_in_delta measurement.pressure_pa, 100_391, 1
@@ -67,7 +67,7 @@ defmodule BMP3XXTest do
 
   @tag sensor_type: :bme280
   test "supports bme280", %{bmp_name: bmp_name} do
-    {:ok, _} = BMP3XX.force_altitude(bmp_name, 100)
+    :ok = BMP3XX.force_altitude(bmp_name, 100)
     {:ok, measurement} = BMP3XX.measure(bmp_name)
     assert_in_delta measurement.temperature_c, 26.7, 0.1
     assert_in_delta measurement.pressure_pa, 100_391, 1
@@ -78,7 +78,7 @@ defmodule BMP3XXTest do
 
   @tag sensor_type: :bme680
   test "supports bme680", %{bmp_name: bmp_name} do
-    {:ok, _} = BMP3XX.force_altitude(bmp_name, 100)
+    :ok = BMP3XX.force_altitude(bmp_name, 100)
     {:ok, measurement} = BMP3XX.measure(bmp_name)
     assert_in_delta measurement.temperature_c, 19.3, 0.1
     assert_in_delta measurement.pressure_pa, 100_977, 1


### PR DESCRIPTION
Standardize on the return value of `force_altitude` to be consistent with [bmp280](https://github.com/elixir-sensors/bmp280).