### PR TITLE
v0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.6
+
+### Fixed
+- Standardize on the return value of `force_altitude` to be consistent with [bmp280](https://github.com/elixir-sensors/bmp280). (was: `{:ok, number}`, now: `:ok`)
+
 ## v0.1.5
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- MODULEDOC -->
 Read temperature and pressure in Elixir from [Bosch environmental
 sensors](https://www.bosch-sensortec.com/products/environmental-sensors/) such
-as BMP180, BMP280, BME280, BME680, BMP388, and BMP390.
+as BMP180, BMP280, BME280, BMP380, BMP390, BME680, etc.
 <!-- MODULEDOC -->
 
 ## Usage

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BMP3XX.MixProject do
   use Mix.Project
 
-  @version "0.1.5"
+  @version "0.1.6"
   @description "Use Bosch environment sensors in Elixir"
   @source_url "https://github.com/mnishiguchi/bmp3xx"
 


### PR DESCRIPTION
### Fixed
- Standardize on the return value of `force_altitude` to be consistent with [bmp280](https://github.com/elixir-sensors/bmp280). (was: `{:ok, number}`, now: `:ok`)